### PR TITLE
experimental volume mount for rolesanywhere

### DIFF
--- a/verification-v2/ts-pkgs/peer-client/Dockerfile
+++ b/verification-v2/ts-pkgs/peer-client/Dockerfile
@@ -1,5 +1,18 @@
 FROM node:22.21-trixie-slim@sha256:1ddaeddded05b2edeaf35fac720a18019e1044a6791509c8670c53c2308301bb
 
+# Install aws_signing_helper for IAM Roles Anywhere credential_process support
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+      curl -Lo /usr/local/bin/aws_signing_helper https://rolesanywhere.amazonaws.com/releases/1.4.0/X86_64/Linux/aws_signing_helper; \
+    elif [ "$ARCH" = "arm64" ]; then \
+      curl -Lo /usr/local/bin/aws_signing_helper https://rolesanywhere.amazonaws.com/releases/1.4.0/ARM64/Linux/aws_signing_helper; \
+    else \
+      echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    chmod +x /usr/local/bin/aws_signing_helper && \
+    apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir --parents verification-v2/ts-pkgs/peer-client verification-v2/ts-pkgs/peer-lib
 COPY .yarn /verification-v2/.yarn
 COPY package.json yarn.lock .yarnrc.yml /verification-v2/

--- a/verification-v2/ts-pkgs/rollout-scripts/register-peer.sh
+++ b/verification-v2/ts-pkgs/rollout-scripts/register-peer.sh
@@ -64,7 +64,6 @@ if [ -n "${TSS_E2E_DOCKER_NETWORK:-}" ]; then
     run_option+="--network ${TSS_E2E_DOCKER_NETWORK} "
 fi
 
-
 docker build ${builder_option} \
     --file "${PROJECT_ROOT}/ts-pkgs/peer-client/Dockerfile" \
     --build-arg TLS_HOSTNAME="${TLS_HOSTNAME}" \
@@ -75,6 +74,10 @@ docker build ${builder_option} \
 
 docker run ${run_option} \
     --rm \
+    --volume ~/.aws:/root/.aws:ro \
+    --volume /etc/rolesanywhere:/etc/rolesanywhere:ro \
+    --env AWS_PROFILE=rolesanywhere \
+    --env AWS_REGION=us-east-2 \
     --volume "${CERT_PATH}:/run/secrets/cert.pem:ro" \
     "register-peer${TSS_E2E_GUARDIAN_ID:-}"
 


### PR DESCRIPTION
Experimental test:
* Installs aws_signing_helper required for rolesanywhere
* mounts rolesanywhere cofing & aws config folder

AWS playbook:

```
To pass AWS credentials to a bare-metal server using IAM Roles Anywhere, you must configure a Public Key Infrastructure (PKI), set up the corresponding AWS resources, and use the AWS IAM Roles Anywhere credential helper tool on the server. This eliminates the need for long-term static AWS credentials.
Prerequisites.

An X.509 Certificate Authority (CA) (either self-managed with OpenSSL or using AWS Private CA).A client certificate and private key issued by the CA for your bare-metal server.AWS CLI and the AWS IAM Roles Anywhere credential helper tool installed on the bare-metal server. 

Step 1: Configure AWS IAM and PKI Resources
Establish a Trust Anchor: In the AWS IAM Roles Anywhere console, create a trust anchor by registering your CA certificate (in PEM format). This establishes trust between your PKI and AWS.

Create an IAM Role: Create an IAM role that your bare-metal server will assume.
Edit the role's trust policy to include the IAM Roles Anywhere service principal ([rolesanywhere.amazonaws.com](http://rolesanywhere.amazonaws.com/)).
Attach the necessary permissions policies that define what AWS resources the server can access.
Create an IAM Roles Anywhere Profile: In the IAM Roles Anywhere console, create a profile. This profile links the trust anchor to the IAM role and can apply optional session policies. 

Step 2: Configure the Bare-Metal Server
Install the Credential Helper: Download the appropriate aws_signing_helper binary for your server's operating system from the IAM Roles Anywhere Credential Helper GitHub repository and make it executable.
Secure Certificates: Place the server's certificate and private key files on the bare-metal server and lock their permissions (e.g., chmod 600).
Configure the AWS CLI: Configure the AWS credentials file (~/.aws/config) to use the credential_process setting. This setting instructs the AWS SDKs and CLI to use the helper tool to automatically fetch and refresh temporary credentials. Add a profile similar to this to your ~/.aws/config file, replacing the placeholder values with your specific information:

[profile rolesanywhere]
credential_process = /path/to/aws_signing_helper credential-process \
    --certificate /path/to/certificate.pem \
    --private-key /path/to/private-key.pem \
    --trust-anchor-arn arn:aws:rolesanywhere:region:account:trust-anchor/TA_ID \
    --profile-arn arn:aws:rolesanywhere:region:account:profile/PROFILE_ID \
    --role-arn arn:aws:iam::account:role/ROLE_ID
region = <your-aws-region>
```